### PR TITLE
Use HTTP default layer functions instead of Cassette

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,15 @@
 name = "BrokenRecord"
 uuid = "bdd55f5b-6e67-4da1-a080-6086e55655a0"
 authors = ["Chris de Graaf <me@cdg.dev> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
-Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
 BSON = "0.2"
-Cassette = "0.3"
-HTTP = "^0.8.15"
-Suppressor = "0.2"
+HTTP = "0.9"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Always feels good to totally rewrite a package's innards and have the unchanged test suite still pass! With this update, Discord.jl's test suite went from 143s to 28s. I feel less wizardlike without Cassette in `[deps]`, but oh well.

Needs https://github.com/JuliaWeb/HTTP.jl/pull/608.