### PR TITLE
README: Don't recommend that users use HTTP.jl via `using BrokenRecord: HTTP`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A [VCR](https://github.com/vcr/vcr) clone in Julia.
 > Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
 
 ```jl
-julia> using BrokenRecord: HTTP, configure!, playback
+julia> using BrokenRecord: configure!, playback
+
+julia> using HTTP
 
 julia> dir = mktempdir();
 


### PR DESCRIPTION
I don't think that we should recommend that users use the HTTP.jl package via `using BrokenRecord: HTTP`.

I think it's better to encourage users to do `using HTTP`. This forces them to add `HTTP` as a direct dependency of their package, which in turn forces them (if they want automerge) to add a `[compat]` entry for `HTTP`.

In contrast, if users do `using BrokenRecord: HTTP`, then they don't need to add a `[compat]` entry for `HTTP`. This means that if, in the future, BrokenRecord.jl supports multiple breaking releases of HTTP.jl, then users could end up having problems in their packages because they did not appropriately restrict their package's compatibility for HTTP.jl.