### PR TITLE
Reorder things to make sure custom layers don't persist on errors

### DIFF
--- a/src/BrokenRecord.jl
+++ b/src/BrokenRecord.jl
@@ -82,17 +82,15 @@ function playback(
         Union{}, RecordingLayer
     end
 
-    insert_default!(before_layer, custom_layer)
     storage, path = get_storage(path, DEFAULTS[:extension])
     before(custom_layer, storage, path)
-    result = try
+    insert_default!(before_layer, custom_layer)
+    return try
         f()
     finally
         remove_default!(before_layer, custom_layer)
         after(custom_layer, storage, path)
     end
-
-    return result
 end
 
 include("recording.jl")


### PR DESCRIPTION
Closes #10

This is only an issue with BrokenRecord bugs, not errors thrown from user-supplied code. So this ought to be a fine fix.